### PR TITLE
drop udisks2 from server profile

### DIFF
--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -36,9 +36,6 @@
   # Enable SSH everywhere
   services.openssh.enable = true;
 
-  # Pretty heavy dependency for a VM
-  services.udisks2.enable = false;
-
   # No need for sound on a server
   sound.enable = false;
 


### PR DESCRIPTION
As far as I can see only desktop environments are enabling this option. This is a rather low-level service, which seems unlikely to get enabled by accident.
However setting this option to false will break `xrdp` in combination with a desktop environment usage which is something you may need every once in a while even in a server context.