### PR TITLE
server: set tcp BBR as default congestion control

### DIFF
--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -81,4 +81,10 @@
       AllowHibernation=no
     '';
   };
+
+  # use TCP BBR has significantly increased throughput and reduced latency for connections
+  boot.kernel.sysctl = {
+    "net.core.default_qdisc" = "fq";
+    "net.ipv4.tcp_congestion_control" = "bbr";
+  };
 }


### PR DESCRIPTION
This is default on GCP for example and in Google’s internal backbone networks and google.com and YouTube Web servers throughput increased by 4 percent on average globally – and by more than 14 percent in some countries.