### PR TITLE
hardware-hetzner-online: add available kernel modules

### DIFF
--- a/hardware/hetzner-online/amd.nix
+++ b/hardware/hetzner-online/amd.nix
@@ -2,6 +2,7 @@
   imports = [ ./. ];
 
   boot.kernelModules = [ "kvm-amd" ];
-  hardware.cpu.amd.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
+  boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "nvme" "usbhid" ];
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
 }

--- a/hardware/hetzner-online/intel.nix
+++ b/hardware/hetzner-online/intel.nix
@@ -2,6 +2,7 @@
   imports = [ ./. ];
 
   boot.kernelModules = [ "kvm-intel" ];
-  hardware.cpu.intel.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
+  boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "sd_mod" "nvme" ];
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
 }


### PR DESCRIPTION
And enable redistributables by default.
