### PR TITLE
add trusted caches mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Config extensions for a given machine.
 - `mixins-telegraf` enables a generic telegraf configuration. See [Mic's dotfiles](https://github.com/Mic92/dotfiles/blob/master/nixos/eva/modules/prometheus/alert-rules.nix)
   for monitoring rules targeting this telegraf configuration.
 - `mixins-nginx` recommended nginx settings
+- `mixins-trusted-nix-caches` list of trust-worthy public binary caches
 
 ### Roles
 

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,7 @@
   mixins-systemd-boot = import ./mixins/systemd-boot.nix;
   mixins-telegraf = import ./mixins/telegraf.nix;
   mixins-terminfo = import ./mixins/terminfo.nix;
+  mixins-trusted-nix-caches = import ./mixins/trusted-nix-caches.nix;
 
   # Roles
   roles-github-actions-runner = import ./roles/github-actions-runner.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,14 @@
             self.nixosModules.mixins-terminfo
           ];
         };
+        example-mixins-trusted-nix-caches = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            dummy
+            fake-hardware
+            self.nixosModules.mixins-trusted-nix-caches
+          ];
+        };
         example-mixins-nginx = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           modules = [

--- a/mixins/trusted-nix-caches.nix
+++ b/mixins/trusted-nix-caches.nix
@@ -1,0 +1,14 @@
+{
+  # Caches in trusted-substituters can be used by unprivileged users i.e. in
+  # flakes but are not enabled by default.
+  nix.settings.trusted-substituters = [
+    "https://nix-community.cachix.org"
+    "https://cache.garnix.io"
+    "https://numtide.cachix.org"
+  ];
+  nix.settings.trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRC"
+    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+    "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+  ];
+}


### PR DESCRIPTION
This adds a list of common trust-worthy caches. It's not enabled by default since it's debatable what caches should be enabled by default.