### PR TITLE
common: drop Nsncd option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675246915,
-        "narHash": "sha256-q3E67PIRNQyWKtg43grNYYAZT/ik9oyOsRvHYah0iJQ=",
+        "lastModified": 1675446098,
+        "narHash": "sha256-xB4doWLd849LKDKqYnTdmteX5TVEfZIH6WiGvj8wMi4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55fbb1d20ce4350aae11bba71844796549175ab1",
+        "rev": "a59fe7abba1be9e515e7333005ff8a36f86876b2",
         "type": "github"
       },
       "original": {

--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -28,9 +28,6 @@
   # unecessary rebuilds.
   environment.noXlibs = false;
 
-  # Use the better version of nscd
-  services.nscd.enableNsncd = true;
-
   # Allow sudo from the @wheel group
   security.sudo.enable = true;
 }


### PR DESCRIPTION
this is now upstream: https://github.com/NixOS/nixpkgs/pull/214153