### PR TITLE
fix: make experimental-features a list

### DIFF
--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -4,7 +4,10 @@
   nix.settings.connect-timeout = 5;
 
   # Enable flakes
-  nix.settings.experimental-features = "nix-command flakes";
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
 
   # The default at 10 is rarely enough.
   nix.settings.log-lines = lib.mkDefault 25;


### PR DESCRIPTION
This fixes the problem, that you cannot add to more experimental features in another config