### PR TITLE
feat(github-runners): add option to install default packages

### DIFF
--- a/nixos/roles/github-actions-runner.nix
+++ b/nixos/roles/github-actions-runner.nix
@@ -86,6 +86,15 @@ in
         type = lib.types.str;
       };
     };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      description = lib.mdDoc ''
+        Extra packages to add to `PATH` of the service to make them available to workflows.
+      '';
+      default = [ ];
+    };
+
   };
 
   config = {
@@ -108,10 +117,10 @@ in
             pkgs.cachix
             pkgs.glibc.bin
             pkgs.jq
-            pkgs.nix
+            config.nix.package
             pkgs.nix-eval-jobs
             pkgs.openssh
-          ];
+          ] ++ cfg.extraPackages;
           extraLabels = [ "nix" ];
         };
       })


### PR DESCRIPTION
Some workflows assume packages to be installed by default (e.g. bld). Sometime helpful to not run devshell in all workflows.