### PR TITLE
remove the _file references

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2,23 +2,3 @@
 
 This page explains some of the design decisions that have been made trough
 this project.
-
-## What are there `_file` attributes in the NixOS modules?
-
-TL;DR: to provide better error reporting.
-
-This is a bit of a subtle issue, combining knowlede about both Flakes and the Nix module system, so please hang with me.
-
-First, there are two types of imports in the Nix ecosystem:
-
-1. The `import` builtin function. This can be used anywhere in the code read a target Nix file, and return the evaluation result in its place.
-2. The `imports` attribute in the Nix module system. This takes a list of either path, attr or function, which is then used to extend the module system with new option of config values.
-
-The reason to add the `_file` attribute is that it's used to report when there are value or type clashes while building the config tree.
-It helps the user be pointed directly to the right location. Typically, NixOS modules are passed as a path, and in that case, the module system transparently annotates the module with the `_file` attribute so you don't see it in most cases.
-
-Now let's talk about flakes.
-
-When running `nix flake check`, Nix expects the NixOS modules to sit in the `nixosModules.<name>` prefix. And that the value is a function. If we give it a path, it will fail the check. So we can't have a path to (2) and therefor need to use (1) and annotate the `_file` manually.
-
-Case closed :)

--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -2,7 +2,7 @@
 # Common configuration accross *all* the machines
 { config, pkgs, lib, ... }:
 {
-  _file = ./default.nix;
+
   imports = [
     ./flake.nix
     ./mdmonitor-fix.nix

--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -1,5 +1,5 @@
 {
-  _file = ./default.nix;
+
   imports = [
     ../common
     ./pipewire.nix

--- a/nixos/hardware/amazon/default.nix
+++ b/nixos/hardware/amazon/default.nix
@@ -1,6 +1,6 @@
 { modulesPath, ... }:
 {
-  _file = ./default.nix;
+
   imports = [
     "${modulesPath}/virtualisation/amazon-image.nix"
     ../../mixins/cloud-init.nix

--- a/nixos/hardware/hetzner-cloud/default.nix
+++ b/nixos/hardware/hetzner-cloud/default.nix
@@ -1,6 +1,6 @@
 { config, modulesPath, lib, ... }:
 {
-  _file = ./default.nix;
+
   imports = [
     ../../mixins/cloud-init.nix
     "${modulesPath}/profiles/qemu-guest.nix"

--- a/nixos/hardware/hetzner-online/amd.nix
+++ b/nixos/hardware/hetzner-online/amd.nix
@@ -1,5 +1,5 @@
 { lib, config, ... }: {
-  _file = ./amd.nix;
+
   imports = [ ./. ];
 
   boot.kernelModules = [ "kvm-amd" ];

--- a/nixos/hardware/hetzner-online/intel.nix
+++ b/nixos/hardware/hetzner-online/intel.nix
@@ -1,5 +1,5 @@
 { lib, config, ... }: {
-  _file = ./intel.nix;
+
   imports = [ ./. ];
 
   boot.kernelModules = [ "kvm-intel" ];

--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  _file = ./cloud-init.nix;
+
   config = {
     services.cloud-init.enable = true;
     services.cloud-init.network.enable = true;

--- a/nixos/mixins/nginx.nix
+++ b/nixos/mixins/nginx.nix
@@ -1,5 +1,5 @@
 { config, lib, ... }: {
-  _file = ./nginx.nix;
+
   networking.firewall.allowedTCPPorts = [ 443 80 ];
 
   services.nginx = {

--- a/nixos/mixins/systemd-boot.nix
+++ b/nixos/mixins/systemd-boot.nix
@@ -1,6 +1,6 @@
 # Add this mixin to machines that boot with EFI
 {
-  _file = ./systemd-boot.nix;
+
   # Only enable during install
   #boot.loader.efi.canTouchEfiVariables = true;
 

--- a/nixos/mixins/telegraf.nix
+++ b/nixos/mixins/telegraf.nix
@@ -9,7 +9,7 @@ let
   hasNvme = lib.any (m: m == "nvme") config.boot.initrd.availableKernelModules;
 in
 {
-  _file = ./telegraf.nix;
+
   systemd.services.telegraf.path = lib.optional (!isVM && hasNvme) pkgs.nvme-cli;
 
   services.telegraf = {

--- a/nixos/mixins/terminfo.nix
+++ b/nixos/mixins/terminfo.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 {
-  _file = ./terminfo.nix;
+
   # various terminfo packages
   environment.systemPackages = [
     pkgs.wezterm.terminfo # this one does not need compilation

--- a/nixos/mixins/tracing.nix
+++ b/nixos/mixins/tracing.nix
@@ -3,7 +3,7 @@
 , lib
 , ...
 }: {
-  _file = ./tracing.nix;
+
   programs.bcc.enable = !pkgs.stdenv.hostPlatform.isRiscV;
   programs.sysdig.enable = !pkgs.stdenv.isAarch64 && !pkgs.stdenv.hostPlatform.isRiscV;
 

--- a/nixos/roles/github-actions-runner.nix
+++ b/nixos/roles/github-actions-runner.nix
@@ -3,7 +3,7 @@ let
   cfg = config.roles.github-actions-runner;
 in
 {
-  _file = ./github-actions-runner.nix;
+
   imports = [
     ../modules/github-runners
   ];

--- a/nixos/roles/nix-remote-builder.nix
+++ b/nixos/roles/nix-remote-builder.nix
@@ -3,7 +3,7 @@ let
   cfg = config.roles.nix-remote-builder;
 in
 {
-  _file = ./nix-remote-builder.nix;
+
 
   options.roles.nix-remote-builder = {
     schedulerPublicKeys = lib.mkOption {

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -2,7 +2,7 @@
 # Common configuration accross *all* the machines
 { config, pkgs, lib, ... }:
 {
-  _file = ./default.nix;
+
   imports = [
     ../common
   ];


### PR DESCRIPTION
After #80, the modules are exposed as paths, and Nix doesn't seem to
complain anymore.

This is probably a change in Nix itself. But that means we don't need
those `_file` anymore.
