### PR TITLE
github-actions-runner: drop kvm extra group

### DIFF
--- a/nixos/roles/github-actions-runner.nix
+++ b/nixos/roles/github-actions-runner.nix
@@ -113,7 +113,6 @@ in
           serviceOverrides = {
             DeviceAllow = [ "/dev/kvm" ];
             PrivateDevices = false;
-            ExtraGroups = [ "kvm" ];
           };
           extraPackages = [
             pkgs.cachix


### PR DESCRIPTION
the systemd option is invalid and the device should be world-readable.