### PR TITLE
fix(github-runner): unregister existing offline runner using GitHub App token

### DIFF
--- a/nixos/modules/github-runners/remove_existing_runner.sh
+++ b/nixos/modules/github-runners/remove_existing_runner.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+
+_GITHUB_HOST=${GITHUB_HOST:="github.com"}
+
+# If URL is not github.com then use the enterprise api endpoint
+if [[ ${GITHUB_HOST} = "github.com" ]]; then
+  URI="https://api.${_GITHUB_HOST}"
+else
+  URI="https://${_GITHUB_HOST}/api/v3"
+fi
+
+API_HEADER="Accept: application/vnd.github+json"
+AUTH_HEADER="Authorization: token ${ACCESS_TOKEN}"
+CONTENT_LENGTH_HEADER="Content-Length: 0"
+
+function get_runner_id() { 
+  # Get the runner id based on its name
+  case ${RUNNER_SCOPE} in
+    org*)
+      _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners"
+      ;;
+
+    ent*)
+      _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners"
+      ;;
+
+    *)
+      _PROTO="https://"
+      # shellcheck disable=SC2116
+      _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+      _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+      _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+      _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+      _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners"
+      ;;
+  esac
+
+  RUNNERS="$(curl -XGET -fsSL \
+    -H "${CONTENT_LENGTH_HEADER}" \
+    -H "${AUTH_HEADER}" \
+    -H "${API_HEADER}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${_FULL_URL}")"
+  ID=$(echo "$RUNNERS" | jq -r '.runners[] | select( (.name == env.RUNNER_NAME) and (.status == "offline") ) | .id')
+  echo "$ID"
+}
+
+RUNNER_ID=$(get_runner_id)
+if [[ $RUNNER_ID == "" ]]; then
+  echo "Runner ${RUNNER_NAME} doesn't exist. Nothing to unregister"
+  exit 0
+fi
+echo "${RUNNER_NAME} is still registered and offline. Forcing removal..."
+
+case ${RUNNER_SCOPE} in
+  org*)
+    _FULL_URL="${URI}/orgs/${ORG_NAME}/actions/runners/${RUNNER_ID}"
+    ;;
+
+  ent*)
+    _FULL_URL="${URI}/enterprises/${ENTERPRISE_NAME}/actions/runners/${RUNNER_ID}"
+    ;;
+
+  *)
+    _PROTO="https://"
+    # shellcheck disable=SC2116
+    _URL="$(echo "${REPO_URL/${_PROTO}/}")"
+    _PATH="$(echo "${_URL}" | grep / | cut -d/ -f2-)"
+    _ACCOUNT="$(echo "${_PATH}" | cut -d/ -f1)"
+    _REPO="$(echo "${_PATH}" | cut -d/ -f2)"
+    _FULL_URL="${URI}/repos/${_ACCOUNT}/${_REPO}/actions/runners/${RUNNER_ID}"
+    ;;
+esac
+
+curl -XDELETE -fsSL \
+  -H "${CONTENT_LENGTH_HEADER}" \
+  -H "${AUTH_HEADER}" \
+  -H "${API_HEADER}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${_FULL_URL}"

--- a/nixos/modules/github-runners/service.nix
+++ b/nixos/modules/github-runners/service.nix
@@ -230,7 +230,7 @@ with lib;
 
       # If running in ephemeral mode, restart the service on-exit (i.e., successful de-registration of the runner)
       # to trigger a fresh registration.
-      Restart = if cfg.ephemeral then "on-success" else "no";
+      Restart = if cfg.ephemeral then "always" else "no";
       # If the runner exits with `ReturnCode.RetryableError = 2`, always restart the service:
       # https://github.com/actions/runner/blob/40ed7f8/src/Runner.Common/Constants.cs#L146
       RestartForceExitStatus = [ 2 ];

--- a/nixos/modules/github-runners/service.nix
+++ b/nixos/modules/github-runners/service.nix
@@ -96,20 +96,28 @@ with lib;
             text = ./token.sh;
           };
 
+          remove_existing_runner = pkgs.writeShellApplication {
+            name = "remove_existing_runner";
+            runtimeInputs = with pkgs;[ jq curl ];
+            text = ./remove_existing_runner.sh;
+          };
+
           unconfigureRunnerGitHubApp = writeScript "unconfigure-github-app" ''
             set -euo pipefail
+            export APP_ID=${cfg.githubApp.id}
+            export APP_LOGIN=${cfg.githubApp.login}
+            export RUNNER_SCOPE="org"
+            export ORG_NAME="${cfg.githubApp.login}"
+            export APP_PRIVATE_KEY=$(cat ${cfg.githubApp.privateKeyFile})
+            ACCESS_TOKEN=$(${app_token}/bin/fetch_access_token)
+            export ACCESS_TOKEN
+            umask 000
+            export RUNNER_NAME=${escapeShellArg cfg.name}
+
             unregister_previous_runner() {
-              RUNNER_ALLOW_RUNASROOT=1 ${cfg.package}/bin/config.sh remove --token "$(cat ${currentConfigTokenPath})" || true
+              ${remove_existing_runner}/bin/remove_existing_runner
             }
             copy_tokens() {
-              export APP_ID=${cfg.githubApp.id}
-              export APP_LOGIN=${cfg.githubApp.login}
-              export RUNNER_SCOPE="org"
-              export ORG_NAME="${cfg.githubApp.login}"
-              export APP_PRIVATE_KEY=$(cat ${cfg.githubApp.privateKeyFile})
-              ACCESS_TOKEN=$(${app_token}/bin/fetch_access_token)
-              export ACCESS_TOKEN
-              umask 000
               ${token}/bin/fetch_runner_token | ${pkgs.jq}/bin/jq -r '.token' > ${newConfigTokenPath}
               ls -l ${newConfigTokenPath}
               install --mode=600 ${newConfigTokenPath} "${currentConfigTokenPath}"

--- a/nixos/modules/github-runners/token.sh
+++ b/nixos/modules/github-runners/token.sh
@@ -24,7 +24,6 @@
 # SOFTWARE.
 
 set -eu
-set -x
 _GITHUB_HOST=${GITHUB_HOST:="github.com"}
 
 # If URL is not github.com then use the enterprise api endpoint


### PR DESCRIPTION
The GitHub self-hosted runner service can unregister existing GitHub runners if their token still exists in the runner's state directory. However, if the runner is still registered and the token no longer exists, the service is unable to unregister the runner, and it cannot be started again as it is already registered.

Rather than relying on the token stored in the runner's state directory, this change enables the service to unregister an existing offline runner using the GitHub App token.