### PR TITLE
feat(github-runner): add optional async post build hook

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -15,6 +15,7 @@ status = [
   "nixosConfig example-mixins-trusted-nix-caches",
   "nixosConfig example-roles-github-actions-runner",
   "nixosConfig example-roles-github-actions-runner-github-app",
+  "nixosConfig example-roles-github-actions-runner-github-app-queued-build-hook",
   "nixosConfig example-roles-nix-remote-builder",
   "nixosConfig example-server",
 ]

--- a/nixos/test-configurations.nix
+++ b/nixos/test-configurations.nix
@@ -133,6 +133,27 @@ in
       }
     ];
   };
+  example-roles-github-actions-runner-github-app-queued-build-hook = nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      self.nixosModules.roles-github-actions-runner
+      dummy
+      {
+        roles.github-actions-runner = {
+          githubApp = {
+            id = "1234";
+            login = "foo";
+            privateKeyFile = "/run/gha-token-file";
+          };
+          url = "https://fixup";
+          binary-cache.script = ''
+            exec nix copy --experimental-features nix-command --to "file:///var/nix-cache" $OUT_PATHS
+          '';
+        };
+      }
+    ];
+  };
+
   example-roles-nix-remote-builder = nixosSystem {
     system = "x86_64-linux";
     modules = [


### PR DESCRIPTION
Add option to enable asynchronous process to upload Nix packages to a binary cache without requiring the use of Cachix. Based on https://github.com/nix-community/queued-build-hook