### PR TITLE
feat(github-runner): add role option to add extra labels

### DIFF
--- a/nixos/roles/github-actions-runner.nix
+++ b/nixos/roles/github-actions-runner.nix
@@ -97,6 +97,15 @@ in
       default = [ ];
     };
 
+    extraLabels = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = lib.mdDoc ''
+        Extra labels to add to the runners to be able to target them.
+      '';
+      default = [ "nix" ];
+    };
+
+
   };
 
   config = {
@@ -122,7 +131,7 @@ in
             pkgs.nix-eval-jobs
             pkgs.openssh
           ] ++ cfg.extraPackages;
-          extraLabels = [ "nix" ];
+          extraLabels = cfg.extraLabels;
         };
       })
       (lib.range 1 cfg.count));


### PR DESCRIPTION
Introduces the `extraLabels` option to the GitHub action runners role, enabling users to target specific runners using custom labels.