### PR TITLE
server: disable documentation by default

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -17,6 +17,7 @@
     pkgs.vim
   ];
 
+  # Notice this also disables --help for some commands such es nixos-rebuild
   documentation.enable = lib.mkDefault false;
 
   programs.vim.defaultEditor = true;


### PR DESCRIPTION
Keep the evaluation and closure size small