### PR TITLE
hetzner-cloud: detect IPv6 automatically

### DIFF
--- a/nixos/hardware/hetzner-cloud/default.nix
+++ b/nixos/hardware/hetzner-cloud/default.nix
@@ -1,22 +1,11 @@
 { config, modulesPath, lib, ... }:
 {
-
   imports = [
     ../../mixins/cloud-init.nix
     "${modulesPath}/profiles/qemu-guest.nix"
   ];
 
   config = {
-    assertions = [
-      {
-        assertion = config.systemd.network.networks."10-uplink".networkConfig ? Address;
-        message = ''
-          The machine IPv6 address must be set to
-          `systemd.network.networks."10-uplink".networkConfig.Address`
-        '';
-      }
-    ];
-
     boot.growPartition = true;
     boot.loader.grub.device = "/dev/sda";
     boot.tmp.cleanOnBoot = true;
@@ -25,16 +14,5 @@
 
     networking.useNetworkd = true;
     networking.useDHCP = false;
-
-    systemd.network.networks."10-uplink" = {
-      matchConfig = {
-        Virtualization = true;
-        Name = "en* eth*";
-      };
-      networkConfig.DHCP = "ipv4";
-      # hetzner requires static ipv6 addresses
-      networkConfig.Gateway = "fe80::1";
-      networkConfig.IPv6AcceptRA = "no";
-    };
   };
 }


### PR DESCRIPTION
Thanks to @jfroche fixing cloud-init in
https://github.com/NixOS/nixpkgs/pull/226216, it's now able to retrieve
the IPv6 address from the metadata server on boot and creates a
/etc/systemd/network/10-cloud-init-eth0.network file that contains it.
