### PR TITLE
Allow upgrade-diff to run during dry-activate

### DIFF
--- a/nixos/common/flake.nix
+++ b/nixos/common/flake.nix
@@ -10,7 +10,7 @@ in
       type = lib.types.nullOr lib.types.raw;
       default = null;
       description = lib.mdDoc ''
-        Flake that the nixos contains the nixos configuration.
+        Flake that contains the nixos configuration.
       '';
     };
 

--- a/nixos/common/upgrade-diff.nix
+++ b/nixos/common/upgrade-diff.nix
@@ -1,9 +1,12 @@
 # MIT Jörg Thalheim - https://github.com/Mic92/dotfiles/blob/c6cad4e57016945c4816c8ec6f0a94daaa0c3203/nixos/modules/upgrade-diff.nix
 { pkgs, ... }:
 {
-  system.activationScripts.diff = ''
+  system.activationScripts.diff = {
+    supportsDryActivation = true;
+    text = ''
     if [[ -e /run/current-system ]]; then
       ${pkgs.nix}/bin/nix --extra-experimental-features nix-command store diff-closures /run/current-system "$systemConfig"
     fi
   '';
+  };
 }

--- a/nixos/common/upgrade-diff.nix
+++ b/nixos/common/upgrade-diff.nix
@@ -5,7 +5,9 @@
     supportsDryActivation = true;
     text = ''
     if [[ -e /run/current-system ]]; then
+      echo "--- diff to current-system"
       ${pkgs.nix}/bin/nix --extra-experimental-features nix-command store diff-closures /run/current-system "$systemConfig"
+      echo "---"
     fi
   '';
   };


### PR DESCRIPTION
This is something I found useful while testing in preparation to roll out srvos to a few of my machines. Should be safe as the `nix store diff-closures` doesn't do writes and is pretty quick.

The delimiters around it makes it easier to parse IMO, but I am happy to remove them :)