### PR TITLE
common: default to boot.tmp.cleanOnBoot=true

### DIFF
--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -35,4 +35,7 @@
 
   # Allow sudo from the @wheel group
   security.sudo.enable = true;
+
+  # Ensure a clean & sparkling /tmp on fresh boots.
+  boot.tmp.cleanOnBoot = lib.mkDefault true;
 }

--- a/nixos/hardware/hetzner-cloud/default.nix
+++ b/nixos/hardware/hetzner-cloud/default.nix
@@ -8,7 +8,6 @@
   config = {
     boot.growPartition = true;
     boot.loader.grub.device = "/dev/sda";
-    boot.tmp.cleanOnBoot = true;
 
     fileSystems."/" = lib.mkDefault { device = "/dev/sda1"; fsType = "ext4"; };
 


### PR DESCRIPTION
Hello! Just noticed that `boot.tmp.cleanOnBoot` is only enabled on hetzner-cloud machines in srvos. Is there any drawback in doing so on all machines by default or shall we change that? :)