### PR TITLE
common: don't log refused network connections

### DIFF
--- a/nixos/common/networking.nix
+++ b/nixos/common/networking.nix
@@ -3,6 +3,10 @@
   # Allow PMTU / DHCP
   networking.firewall.allowPing = true;
 
+  # Keep dmesg/journalctl -k output readable by NOT logging
+  # each refused connection on the open internet.
+  networking.firewall.logRefusedConnections = lib.mkDefault false;
+
   # Use networkd instead of the pile of shell scripts
   networking.useNetworkd = lib.mkDefault true;
   networking.useDHCP = lib.mkDefault false;


### PR DESCRIPTION
Hello! 

I think not logging each and every refused connection is a good default, as running a public server quickly leads to unreadable dmesg output, due to scanning et al.