### PR TITLE
openssh: use recommended key exchange algorithms

### DIFF
--- a/nixos/common/openssh.nix
+++ b/nixos/common/openssh.nix
@@ -6,6 +6,15 @@
     settings.KbdInteractiveAuthentication = false;
     settings.PasswordAuthentication = false;
     settings.UseDns = false;
+
+    # Use key exchange algorithms recommended by `nixpkgs#ssh-audit`
+    settings.KexAlgorithms = [
+      "curve25519-sha256"
+      "curve25519-sha256@libssh.org"
+      "diffie-hellman-group16-sha512"
+      "diffie-hellman-group18-sha512"
+      "sntrup761x25519-sha512@openssh.com"
+    ];
     # Only allow system-level authorized_keys to avoid injections.
     # We currently don't enable this when git-based software that relies on this is enabled.
     # It would be nicer to make it more granular using `Match`.


### PR DESCRIPTION
Harden the OpenSSH server. This change reduces the compatibility to OpenSSH 6.5 and later.

PortZero's security review inspired this change.