### PR TITLE
common: pin to nix to v2.16 for now

### DIFF
--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -1,5 +1,8 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
+  # Use a version of Nix that works
+  nix.package = pkgs.nixVersions.nix_2_16;
+
   # Fallback quickly if substituters are not available.
   nix.settings.connect-timeout = 5;
 


### PR DESCRIPTION
Nixpkgs distributed nix 2.15 which breaks on nix-copy-closure.
