### PR TITLE
Revert "common: pin to nix to v2.16 for now"

### DIFF
--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -1,8 +1,5 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
-  # Use a version of Nix that works
-  nix.package = lib.mkDefault pkgs.nixVersions.nix_2_16;
-
   # Fallback quickly if substituters are not available.
   nix.settings.connect-timeout = 5;
 


### PR DESCRIPTION
nixpkgs now defaults to nix v2.17

This reverts commit f61c861e67ebac21b105dfe32c72c4fc19e3678c introduced in #208