### PR TITLE
feat(github-runners): add 'nodeRuntimes' option

### DIFF
--- a/nixos/modules/github-runners/options.nix
+++ b/nixos/modules/github-runners/options.nix
@@ -199,4 +199,12 @@ with lib;
     default = null;
     defaultText = literalExpression "username";
   };
+
+  nodeRuntimes = mkOption {
+    type = with types; nonEmptyListOf (enum [ "node16" "node20" ]);
+    default = [ "node20" ];
+    description = mdDoc ''
+      List of Node.js runtimes the runner should support.
+    '';
+  };
 }

--- a/nixos/modules/github-runners/service.nix
+++ b/nixos/modules/github-runners/service.nix
@@ -20,6 +20,9 @@
 
 with lib;
 
+let
+  package = cfg.package.override { inherit (cfg) nodeRuntimes; };
+in
 {
   description = "GitHub Actions runner";
 
@@ -62,7 +65,7 @@ with lib;
       '';
     in
     rec {
-      ExecStart = "${cfg.package}/bin/Runner.Listener run --startuptype service";
+      ExecStart = "${package}/bin/Runner.Listener run --startuptype service";
 
       # Does the following, sequentially:
       # - If the module configuration or the token has changed, purge the state directory,
@@ -191,7 +194,7 @@ with lib;
               else
                 args+=(--token "$token")
               fi
-              ${cfg.package}/bin/config.sh "''${args[@]}"
+              ${package}/bin/config.sh "''${args[@]}"
               # Move the automatically created _diag dir to the logs dir
               mkdir -p  "$STATE_DIRECTORY/_diag"
               cp    -r  "$STATE_DIRECTORY/_diag/." "$LOGS_DIRECTORY/"
@@ -220,7 +223,7 @@ with lib;
       ExecStopPost =
         let
           unregisterScript = writeScript "unregister-runner" ''
-            RUNNER_ALLOW_RUNASROOT=1 ${cfg.package}/bin/config.sh remove --token "$(cat ${currentConfigTokenPath})" || true
+            RUNNER_ALLOW_RUNASROOT=1 ${package}/bin/config.sh remove --token "$(cat ${currentConfigTokenPath})" || true
           '';
         in
         map (x: "${x} ${escapeShellArgs [ stateDir runtimeDir logsDir ]}") [

--- a/nixos/roles/github-actions-runner.nix
+++ b/nixos/roles/github-actions-runner.nix
@@ -153,7 +153,13 @@ in
       default = [ "nix" ];
     };
 
-
+    nodeRuntimes = lib.mkOption {
+      type = with lib.types; nonEmptyListOf (enum [ "node16" "node20" ]);
+      default = [ "node20" ];
+      description = lib.mdDoc ''
+        List of Node.js runtimes the runner should support.
+      '';
+    };
   };
 
   config = {
@@ -169,6 +175,7 @@ in
           tokenFile = cfg.tokenFile;
           githubApp = cfg.githubApp;
           ephemeral = cfg.ephemeral;
+          nodeRuntimes = cfg.nodeRuntimes;
           serviceOverrides = {
             DeviceAllow = [ "/dev/kvm" ];
             PrivateDevices = false;


### PR DESCRIPTION
As many actions don't yet support Node 20 it is useful to be able to specify which versions should be available. This PR makes that possible by incorporating the changes found [here](https://github.com/NixOS/nixpkgs/pull/249103/commits/388bfcef4a51efb55b2b447d2634d16ce486d32c).

At the time of writing the CI is failing because Node 16 is required.