### PR TITLE
hetzner-online: use predictable interface names

### DIFF
--- a/nixos/hardware/hetzner-online/default.nix
+++ b/nixos/hardware/hetzner-online/default.nix
@@ -32,7 +32,7 @@
     networking.useDHCP = false;
 
     systemd.network.networks."10-uplink" = {
-      matchConfig.Name = "eno1 ens1 enp1s0 eth0";
+      matchConfig.Name = lib.mkDefault "eno1 ens1 enp1s0 eth0";
       networkConfig.DHCP = "ipv4";
       # hetzner requires static ipv6 addresses
       networkConfig.Gateway = "fe80::1";

--- a/nixos/hardware/hetzner-online/default.nix
+++ b/nixos/hardware/hetzner-online/default.nix
@@ -32,7 +32,7 @@
     networking.useDHCP = false;
 
     systemd.network.networks."10-uplink" = {
-      matchConfig.Name = lib.mkDefault "eno1 ens1 enp1s0 eth0";
+      matchConfig.Name = lib.mkDefault "en* eth0";
       networkConfig.DHCP = "ipv4";
       # hetzner requires static ipv6 addresses
       networkConfig.Gateway = "fe80::1";

--- a/nixos/hardware/hetzner-online/default.nix
+++ b/nixos/hardware/hetzner-online/default.nix
@@ -30,11 +30,9 @@
 
     networking.useNetworkd = true;
     networking.useDHCP = false;
-    # Hetzner servers commonly only have one interface, so its either to just match by that.
-    networking.usePredictableInterfaceNames = false;
 
     systemd.network.networks."10-uplink" = {
-      matchConfig.Name = "eth0";
+      matchConfig.Name = "eno1 ens1 enp1s0 eth0";
       networkConfig.DHCP = "ipv4";
       # hetzner requires static ipv6 addresses
       networkConfig.Gateway = "fe80::1";


### PR DESCRIPTION
...and match probable names of the first interface according to
https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

matchConfig.Name is a whitespace-separated list of shell-style globs according to man 5 systemd.network.

old-style eth0 is kept to ease switching between interface naming schemes and because it seems harmless to do so.