### PR TITLE
telegraf: add internal

### DIFF
--- a/nixos/mixins/telegraf.nix
+++ b/nixos/mixins/telegraf.nix
@@ -129,6 +129,7 @@ in
           device = [ "rpc_pipefs" "lxcfs" "nsfs" "borgfs" ];
         };
         diskio = { };
+        internal = { };
         zfs = {
           poolMetrics = true;
         };


### PR DESCRIPTION
Useful to see drops/errors/timeouts from the agent.