### PR TITLE
nix-daemon: enable more experimental features

### DIFF
--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -7,6 +7,9 @@
   nix.settings.experimental-features = [
     "nix-command"
     "flakes"
+    "repl-flake"
+    "impure-derivations"
+    "auto-allocate-uids"
   ];
 
   # The default at 10 is rarely enough.


### PR DESCRIPTION
Impure-derivations and auto-allocate-uids seem to be pretty stable and are not used if not requested by a build. repl-flake changes the behaviour of nix repl, but this change will be considered stable in the next release anyway.