### PR TITLE
treewide: fix typo using typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ example to deploy a GitHub Action runner on Hetzner:
   inputs = {
     srvos.url = "github:nix-community/srvos";
     # Use the version of nixpkgs that has been tested to work with SrvOS
-    # Alternativly we also support the latest nixos release and unstable
+    # Alternatively we also support the latest nixos release and unstable
     nixpkgs.follows = "srvos/nixpkgs";
   };
   outputs = { self, nixpkgs, srvos }: {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@ Some questions and answers that haven't been integrated in the documentation yet
 
 SrvOS is currently tested against `nixos-unstable` and the latest NixOS release. SrvOS itself is automatically updated and tested against the latest version of that channel once a week.
 
-If you want to make sure to use a tested version, use the "follows" mechanims of Nix flakes to pull the same version as the one of SrvOS:
+If you want to make sure to use a tested version, use the "follows" mechanisms of Nix flakes to pull the same version as the one of SrvOS:
 
 ```nix
 {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,7 @@ In this documentation, we expect the reader to be already familiar with the base
 This project exports four big categories of NixOS modules which are useful to define a server configuration:
 
 * Machine type - these are high-level settings that define the machine type (Eg: common, server or desktop). Only one of those would be included.
-* Machine hardware - these define hardware-releated settings for well known hardware. Only one of those would be included. (eg: AWS EC2 instances).
+* Machine hardware - these define hardware-related settings for well known hardware. Only one of those would be included. (eg: AWS EC2 instances).
 * Machine role - theses take over a machine for a specific role. Only one of those would be included. (eg: GitHub Actions runner)
 * Configuration mixins - these define addons to be added to the machine configuration. One or more can be added.
 
@@ -23,7 +23,7 @@ Combining all of those together, here is how your `flake.nix` might look like, t
   inputs = {
     srvos.url = "github:nix-community/srvos";
     # Use the version of nixpkgs that has been tested to work with SrvOS
-    # Alternativly we also support the latest nixos release and unstable
+    # Alternatively we also support the latest nixos release and unstable
     nixpkgs.follows = "srvos/nixpkgs";
   };
   outputs = { self, nixpkgs, srvos }: {

--- a/docs/nixos/hardware.md
+++ b/docs/nixos/hardware.md
@@ -32,7 +32,7 @@ Introduces some workaround for the particular IPv6 configuration that Hetzner ha
 
 Hardware configuration for <https://www.hetzner.com/dedicated-rootserver> bare-metal Intel servers.
 
-Introduces some workaround for the perticular IPv6 configuration that Hetzner has.
+Introduces some workaround for the particular IPv6 configuration that Hetzner has.
 
 ### `nixosModules.hardware-hetzner-online-ex101`
 

--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -1,5 +1,5 @@
 # A default configuration that applies to all servers.
-# Common configuration accross *all* the machines
+# Common configuration across *all* the machines
 { config, lib, ... }:
 {
 
@@ -34,7 +34,7 @@
 
   environment = {
     # This is pulled in by the container profile, but it seems broken and causes
-    # unecessary rebuilds.
+    # unnecessary rebuilds.
     noXlibs = false;
   } // lib.optionalAttrs (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.05") {
     # Don't install the /lib/ld-linux.so.2 stub. This saves one instance of

--- a/nixos/desktop/pipewire.nix
+++ b/nixos/desktop/pipewire.nix
@@ -1,4 +1,4 @@
-# Use pipewire instead of PuleseAudio. See https://nixos.wiki/wiki/PipeWire
+# Use pipewire instead of PulseAudio. See https://nixos.wiki/wiki/PipeWire
 { lib, config, ... }:
 {
   security.rtkit.enable = lib.mkDefault config.services.pipewire.enable;

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -1,5 +1,5 @@
 # A default configuration that applies to all servers.
-# Common configuration accross *all* the machines
+# Common configuration across *all* the machines
 { pkgs, lib, ... }:
 {
 


### PR DESCRIPTION
Saw a [typo](https://github.com/nix-community/srvos/blob/6f5c52bcd3b9e7c0e88907a75d284d11b609a36c/nixos/desktop/pipewire.nix#L1C27-L1C38) and decided to grab [typos](https://github.com/crate-ci/typos)