### PR TITLE
network sysctls

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -111,10 +111,56 @@
     '';
   };
 
-  # use TCP BBR has significantly increased throughput and reduced latency for connections
+  # https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html
+  # In some cases, TCP BBR can significantly increase throughput and reduce latency,
+  # however this is not true in all cases, and should be used with caution
   boot.kernel.sysctl = {
     "net.core.default_qdisc" = "fq";
     "net.ipv4.tcp_congestion_control" = "bbr";
+    # "net.ipv4.tcp_congestion_control" = "cubic";
+
+    # Increase TCP buffer sizes for increased throughput
+    "net.ipv4.tcp_rmem" = "4096	1000000	16000000";
+    "net.ipv4.tcp_wmem" = "4096	1000000	16000000";
+    # Default kernel
+    #net.ipv4.tcp_rmem = 4096       131072  6291456
+    #net.ipv4.tcp_wmem = 4096       16384   4194304
+
+    # https://github.com/torvalds/linux/blob/master/Documentation/networking/ip-sysctl.rst?plain=1#L1042
+    # https://lwn.net/Articles/560082/
+    "net.ipv4.tcp_notsent_lowat" = "131072";
+    #net.ipv4.tcp_notsent_lowat = 4294967295
+
+    # Enable reuse of TIME-WAIT sockets globally
+    "net.ipv4.tcp_tw_reuse" = 1;
+    #net.ipv4.tcp_tw_reuse=2
+    "net.ipv4.tcp_timestamps" = 1;
+    "net.ipv4.tcp_ecn" = 1;
+
+    # For machines with a lot of UDP traffic increase the buffers
+    "net.core.rmem_default" = 26214400;
+    "net.core.rmem_max" = 26214400;
+    "net.core.wmem_default" = 26214400;
+    "net.core.wmem_max" = 26214400;
+    #net.core.optmem_max = 20480
+    #net.core.rmem_default = 212992
+    #net.core.rmem_max = 212992
+    #net.core.wmem_default = 212992
+    #net.core.wmem_max = 212992
+
+    # Increase ephemeral ports
+    "net.ipv4.ip_local_port_range" = "1025 65535";
+    #net.ipv4.ip_local_port_range ="32768 60999"
+
+    # detect dead connections more quickly
+    "net.ipv4.tcp_keepalive_intvl" = 30;
+    #net.ipv4.tcp_keepalive_intvl = 75
+    "net.ipv4.tcp_keepalive_probes" = 4;
+    #net.ipv4.tcp_keepalive_probes = 9
+    "net.ipv4.tcp_keepalive_time" = 120;
+    #net.ipv4.tcp_keepalive_time = 7200
+    # 30 * 4 = 120 seconds. / 60 = 2 minutes
+    # default: 75 seconds * 9 = 675 seconds. /60 = 11.25 minutes
   };
 
   # Make sure the serial console is visible in qemu when testing the server configuration


### PR DESCRIPTION
G'day numtide,

Thanks for all the great numtide projects!  I've been learning Nix and you guys are definitely leaders.  Thank you.

In the spirit of giving back, I was reading the blog about SrvOS ( https://numtide.com/blog/donating-srvos-to-nix-community/ ), and took a quick look.  I noticed some standard TCP performance tweaks I apply are missing (most importantly the TCP buffer sizes), and these tweaks will likely be suitable in the vast majority of cases.  Therefore, I submit this little pull request for your thoughts.

It's interesting to see that you ARE changing to BBR-TCP by default.  This is probably mostly safe across the WAN, but BBR is not a silver bullet, and in many cases (like any connection with low RTTs) is likely to be making performance worse.  I did a lot of testing at Edgecast CDN, and we determined NOT to change to BBR, but would selectively switch to BBR for some destination subnets

https://edg.io/technical-articles/improving-network-performance-with-dynamic-congestion-control/

Thanks again,
Dave
