### PR TITLE
Revert "prometheus: fix TelegrafDown host extraction for IPv6 addresses"

### DIFF
--- a/nixos/roles/prometheus/default-alerts.nix
+++ b/nixos/roles/prometheus/default-alerts.nix
@@ -115,7 +115,7 @@
       };
 
       TelegrafDown = {
-        expr = ''label_replace(label_replace(min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org), "host", "$1", "instance", "^\\[([^\\]]+)\\]:[0-9]+$"), "host", "$1", "instance", "^([^.:]+).*") == 0'';
+        expr = ''label_replace(min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org), "host", "$1", "instance", "([^.:]+).*") == 0'';
         for = "3m";
         annotations.description = "{{$labels.instance}}: telegraf exporter from {{$labels.instance}} is down";
       };


### PR DESCRIPTION
This reverts commit 0b3026958df11dbd14d09b3d8923ecb9ea3f43c2.

confused git push with git pull when when trying to remove this commit.