### PR TITLE
website: publish to srvos.org

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: "${{ steps.build.outputs.result }}/"
+          cname: srvos.org


### PR DESCRIPTION
The Namecheap redirect was only handling HTTP, not HTTPS.

Fixes #698