### PR TITLE
perf(swap): make desktops less swappy and more snappy

### DIFF
--- a/nixos/desktop/default.nix
+++ b/nixos/desktop/default.nix
@@ -11,4 +11,6 @@
 
   # improve desktop responsiveness when updating the system
   nix.daemonCPUSchedPolicy = "idle";
+
+  boot.kernel.sysctl."vm.swappiness" = lib.mkDefault 10; # Default is 60, lower is less eager to swap
 }


### PR DESCRIPTION
As [the Ubuntu docs][1] explain, 10 is the recommended swappiness for a
desktop computer. The system will look snappier when recovering from
situations where it had to swap.

[1]:
https://help.ubuntu.com/community/SwapFaq#What_is_swappiness_and_how_do_I_change_it.3F
