### PR TITLE
Remove default DHCP setting in cloud-init mixin

### DIFF
--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -22,7 +22,6 @@
   );
 
   networking.useNetworkd = lib.mkDefault true;
-  networking.useDHCP = lib.mkDefault false;
 
   # Delegate the hostname setting to cloud-init by default
   networking.hostName = lib.mkOverride 1337 ""; # lower prio than lib.mkDefault


### PR DESCRIPTION
This can only raise an error as it conflicts with the default set by nixos.

There is also no reason to force dhcp to false just because one wants cloud init.

It works very well for me even if dhcp is enabled.