### PR TITLE
fix(nginx): prevent infinite recursion in sslDhparam

### DIFF
--- a/nixos/mixins/nginx.nix
+++ b/nixos/mixins/nginx.nix
@@ -33,11 +33,6 @@
       in
       map escapeIPv6 resolvers;
 
-    sslDhparam = config.security.dhparams.params.nginx.path;
-  };
-
-  security.dhparams = {
-    enable = true;
-    params.nginx = { };
+    sslDhparam = true;
   };
 }


### PR DESCRIPTION
This is in line with https://github.com/NixOS/nixpkgs/commit/1d74c186d4e7b3237c236eaeac6bc88c2904b560
Running the [latest revision of nixpkgs/nixos-unstable](https://github.com/NixOS/nixpkgs/tree/62dc67aa6a52b4364dd75994ec00b51fbf474e50) broke because of infinite recursion

       … while evaluating definitions from `/nix/store/92fchhw7gy5lbd6h16ah5ywbn9wj2njq-source/nixos/mixins/nginx.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: infinite recursion encountered
       at /nix/store/8qdril1hgrp7080pvab8af4hmz1i4fpq-source/lib/modules.nix:1159:7:
         1158|     // {
         1159|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1160|       inherit (res.defsFinal') highestPrio;
