### PR TITLE
flake: stabilize private flake path for getFlake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,12 @@
       loadPrivateFlake =
         path:
         let
+          stablePath = builtins.path {
+            inherit path;
+            name = "srvos-dev-private";
+          };
           flakeHash = nixpkgs.lib.fileContents "${toString path}.narHash";
-          flakePath = "path:${toString path}?narHash=${flakeHash}";
+          flakePath = "path:${builtins.unsafeDiscardStringContext (toString stablePath)}?narHash=${flakeHash}";
         in
         builtins.getFlake (builtins.unsafeDiscardStringContext flakePath);
 


### PR DESCRIPTION
## What

Fix `nix flake show` failing when evaluating dev outputs due to an unstable/ephemeral store path for `./dev/private`.

## Why

The previous `loadPrivateFlake` implementation built the flake reference directly from `toString path`:

```nix
flakePath = "path:${toString path}?narHash=${flakeHash}";
```

Under some evaluation contexts this can point at a transient source path that disappears during/after evaluation, leading to:

```
error: path '/nix/store/...-source/dev/private/flake.nix' does not exist
```

## Change

In `flake.nix`, materialize a stable store path for the private flake directory before calling `getFlake`:

```nix
stablePath = builtins.path {
  inherit path;
  name = "srvos-dev-private";
};
flakePath = "path:${builtins.unsafeDiscardStringContext (toString stablePath)}?narHash=${flakeHash}";
```

This keeps behavior the same while making the referenced path deterministic and long-lived enough for flake evaluation.

## Verification

- `nix flake show` (local checkout) now succeeds.
- `nix eval .#checks --apply builtins.attrNames --json` succeeds.
- `nix flake show git+file:///Users/ianmh/Developer/personal/srvos?rev=fb9c345727a38bb598bd98c0b09e75d966fc9df6` succeeds.

