### PR TITLE
darwin/homebrew: remove deprecated flag

### DIFF
--- a/darwin/common/homebrew.nix
+++ b/darwin/common/homebrew.nix
@@ -13,8 +13,6 @@
     ''
   );
 
-  # Don't quarantine apps installed by homebrew with gatekeeper
-  homebrew.caskArgs.no_quarantine = lib.mkDefault true;
   # Declarative package management by removing all homebrew packages,
   # not declared in darwin-nix configuration
   homebrew.onActivation.cleanup = lib.mkDefault "uninstall";


### PR DESCRIPTION
Fixes #796 

Without this `brew` fails to install casks complaining about the use of the deprecated `--no-qurantine` flag. This became an error in Homebrew 5.1.0, which released last month.