### PR TITLE
nix-experimental: advertise recursive-nix in system-features

### DIFF
--- a/darwin/common/nix.nix
+++ b/darwin/common/nix.nix
@@ -15,4 +15,20 @@
 
   # If the user is in @admin they are trusted by default.
   nix.settings.trusted-users = [ "@admin" ];
+
+  # Deprioritize store maintenance I/O so it doesn't starve interactive use.
+  # Both services run as root and use LocalStore directly (not via nix-daemon),
+  # so throttling must be on the launchd service itself.
+  # This mirrors the NixOS side which uses IOSchedulingClass = "idle".
+  launchd.daemons.nix-optimise.serviceConfig = {
+    ProcessType = "Background";
+    LowPriorityIO = true;
+    Nice = 15;
+  };
+
+  launchd.daemons.nix-gc.serviceConfig = {
+    ProcessType = "Background";
+    LowPriorityIO = true;
+    Nice = 15;
+  };
 }

--- a/darwin/mixins/nix-experimental.nix
+++ b/darwin/mixins/nix-experimental.nix
@@ -32,4 +32,8 @@
   ++ lib.optionals (lib.versionAtLeast (lib.versions.majorMinor config.nix.package.version) "2.29") [
     "blake3-hashes"
   ];
+
+  # Advertise recursive-nix so drvs that require it are only scheduled
+  # on builders that support it.
+  nix.settings.system-features = [ "recursive-nix" ];
 }

--- a/nixos/mixins/nix-experimental.nix
+++ b/nixos/mixins/nix-experimental.nix
@@ -42,6 +42,10 @@
   # Needs a patch in Nix to work properly: https://github.com/NixOS/nix/pull/13135
   # nix.settings.use-cgroups = true;
 
-  # for container in builds support
-  nix.settings.system-features = [ "uid-range" ];
+  # uid-range: container-in-builds. recursive-nix: so drvs that require
+  # it are not scheduled on builders without it.
+  nix.settings.system-features = [
+    "uid-range"
+    "recursive-nix"
+  ];
 }


### PR DESCRIPTION
Without it, `requiredSystemFeatures = [ "recursive-nix" ]` drvs get scheduled on builders that do not support recursive-nix, which crashes the nix-daemon.