### PR TITLE
darwin/common/nix: guard gc/optimise launchd.daemons

### DIFF
--- a/darwin/common/nix.nix
+++ b/darwin/common/nix.nix
@@ -20,15 +20,19 @@
   # Both services run as root and use LocalStore directly (not via nix-daemon),
   # so throttling must be on the launchd service itself.
   # This mirrors the NixOS side which uses IOSchedulingClass = "idle".
-  launchd.daemons.nix-optimise.serviceConfig = {
-    ProcessType = "Background";
-    LowPriorityIO = true;
-    Nice = 15;
+  launchd.daemons.nix-optimise = lib.mkIf config.nix.optimise.automatic {
+    serviceConfig = {
+      ProcessType = "Background";
+      LowPriorityIO = true;
+      Nice = 15;
+    };
   };
 
-  launchd.daemons.nix-gc.serviceConfig = {
-    ProcessType = "Background";
-    LowPriorityIO = true;
-    Nice = 15;
+  launchd.daemons.nix-gc = lib.mkIf config.nix.gc.automatic {
+    serviceConfig = {
+      ProcessType = "Background";
+      LowPriorityIO = true;
+      Nice = 15;
+    };
   };
 }


### PR DESCRIPTION
avoids installing these plists when the services aren't enabled