### PR TITLE
nixos: don't shadow upstream initrd default

### DIFF
--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -32,11 +32,6 @@
     )
   ) (lib.mkDefault true);
 
-  # Use systemd during boot as well except:
-  # - systems with raids as this currently require manual configuration: https://github.com/NixOS/nixpkgs/issues/210210
-  # - for containers we currently rely on the `stage-2` init script that sets up our /etc
-  boot.initrd.systemd.enable = lib.mkDefault (!config.boot.swraid.enable && !config.boot.isContainer);
-
   # Don't install the /lib/ld-linux.so.2 stub. This saves one instance of nixpkgs.
   environment.ldso32 = null;
 


### PR DESCRIPTION
Using `boot.swraid.enable` to determine whether a system uses RAID is not very accurate as it is enabled by default for all machines older than 23.11 ([nixpkgs#183314]) and the main blocker mentioned is no longer the case ([nixpkgs#517834]). The `boot.isContainer` part is also no longer necessary either due to the if guard being changed to include `boot.initrd.enable` (which defaults to `!boot.isContainer`) in [nixpkgs#441777].

This change should not affect many machines as it only changes machines with state version < 23.11 or RAID to start using systemd in stage 1 which should not cause any issues as it is now the upstream default as of [nixpkgs#435781].

[nixpkgs#183314]: https://github.com/NixOS/nixpkgs/pull/183314
[nixpkgs#517834]: https://github.com/NixOS/nixpkgs/pull/517834
[nixpkgs#441777]: https://github.com/NixOS/nixpkgs/pull/441777
[nixpkgs#435781]: https://github.com/NixOS/nixpkgs/pull/435781