### PR TITLE
nixos/mixins/mdns: align per-interface key with nixpkgs convention (40-<iface>)

### DIFF
--- a/nixos/mixins/mdns.nix
+++ b/nixos/mixins/mdns.nix
@@ -13,6 +13,11 @@ in
         "99-ethernet-default-dhcp".networkConfig.MulticastDNS = lib.mkDefault true;
         "99-wireless-client-dhcp".networkConfig.MulticastDNS = lib.mkDefault true;
       }
-      // builtins.mapAttrs (_: _: { networkConfig.MulticastDNS = lib.mkDefault true; }) dhcpInterfaces;
+      // lib.mapAttrs' (
+        name: _:
+        lib.nameValuePair "40-${name}" {
+          networkConfig.MulticastDNS = lib.mkDefault true;
+        }
+      ) dhcpInterfaces;
   };
 }


### PR DESCRIPTION
Closes #812.

## Background

The mdns mixin's per-interface arm writes `systemd.network.networks.<iface> = { networkConfig.MulticastDNS = true; };` with the bare interface name as the key. nixpkgs' `tasks/network-interfaces-systemd.nix:100` writes the per-interface DHCP config under `systemd.network.networks."40-${i.name}"`.

When something sets `networking.interfaces.<iface>.useDHCP = true` per-interface (which `nixos-facter-modules` does), the two contributions end up in separate `.network` files: `40-<iface>.network` with `[Match] Name=<iface>` and DHCP, and `<iface>.network` with `[Network] MulticastDNS=true` and no `[Match]` section.

systemd-networkd processes `.network` files in lexical order and the first match wins per interface (`man systemd.network`). `40-<iface>.network` sorts before `<iface>.network` and matches first, so `MulticastDNS` is never applied.

The global `networking.useDHCP = true` path is unaffected: the mixin's other arm targets `99-ethernet-default-dhcp` and `99-wireless-client-dhcp`, which match nixpkgs' generic DHCP file keys exactly.

## Change

Align the per-interface key with the nixpkgs convention (`"40-${name}"` instead of bare `<name>`). The Nix module system then folds both contributions into a single `40-<iface>.network` with `[Match]`, `DHCP=yes`, and `MulticastDNS=true`.

## Validation

Reproduction flake (eval + rendered `.network` inspection): https://github.com/abstracts33d/srvos-812-repro

|   | upstream (buggy) | this PR |
|---|---|---|
| `systemd.network.networks` keys | `["40-eth0","40-eth1","eth0","eth1"]` | `["40-eth0","40-eth1"]` |
| `40-eth0.network` content | `[Match] Name=eth0` + `DHCP=yes` | `[Match] Name=eth0` + `DHCP=yes` + `MulticastDNS=true` |
| bare `eth0.network` | exists with `[Network] MulticastDNS=true` and no `[Match]` | absent |
| global `useDHCP = true` path | works (unchanged) | works (unchanged) |

Reporter (@Kranzes) confirmed the approach on the issue.
