### PR TITLE
nixos/mixins/telegraf: fix warning

### DIFF
--- a/nixos/mixins/telegraf.nix
+++ b/nixos/mixins/telegraf.nix
@@ -52,7 +52,7 @@ let
           // (
             let
               # also match ipv6 addresses
-              group = builtins.match "\\[?([^\]]+)]?:([^:]+)$" fs.device;
+              group = builtins.match "\\[?([^]]+)]?:([^:]+)$" fs.device;
               host = builtins.head group;
               path = builtins.elemAt group 1;
             in


### PR DESCRIPTION
```console
warning: \] is an ill-defined escape. You can drop the \ and simply write ] instead. Use --extra-deprecated-features broken-string-escape to silence this warning.
         at /nix/store/y3k8calmrjynbgb1dsymklkv12qbax5q-source/nixos/mixins/telegraf.nix:55:47:
             54|               # also match ipv6 addresses
             55|               group = builtins.match "\\[?([^\]]+)]?:([^:]+)$" fs.device;
               |                                               ^
             56|               host = builtins.head group;
```