### PR TITLE
nixos/modules: add google-cloud-ops-agent

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -24,6 +24,7 @@ exposeModules ./. [
   ./mixins/terminfo.nix
   ./mixins/tracing.nix
   ./mixins/trusted-nix-caches.nix
+  ./modules/google-cloud-ops-agent
   ./roles/github-actions-runner.nix
   ./roles/nix-remote-builder.nix
   ./roles/prometheus

--- a/nixos/modules/google-cloud-ops-agent/default.nix
+++ b/nixos/modules/google-cloud-ops-agent/default.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  google-cloud-ops-agent = pkgs.callPackage ./google-cloud-ops-agent.nix { };
+  google-cloud-ops-agent-opentelemetry-collector =
+    pkgs.callPackage ./google-cloud-ops-agent-opentelemetry-collector.nix
+      { };
+  settingsFormat = pkgs.formats.json { };
+  cfg = config.services.google-cloud-ops-agent;
+  configFile = settingsFormat.generate "config.yaml" cfg.settings;
+in
+{
+  options = {
+    services.google-cloud-ops-agent.enable = lib.mkEnableOption "Google Cloud Ops Agent";
+    services.google-cloud-ops-agent.settings = lib.mkOption rec {
+      type = settingsFormat.type;
+      default = { };
+      description = lib.mdDoc ''
+        Configuration for Google Cloud Ops Agent. See
+        https://cloud.google.com/monitoring/agent/monitoring/configuration
+        for supported values.
+      '';
+    };
+  };
+  config = lib.mkIf config.services.google-cloud-ops-agent.enable {
+    users.users.google-cloud-ops-agent = {
+      isSystemUser = true;
+      group = "google-cloud-ops-agent";
+      description = "Google Cloud Ops Agent user";
+      extraGroups = [ "systemd-journal" ]; # Needed to read systemd logs
+    };
+
+    users.groups.google-cloud-ops-agent = { };
+
+    systemd.services.google-cloud-ops-agent-fluent-bit = {
+      description = "Google Cloud Ops Agent - Fluent Bit";
+      wantedBy = [ "multi-user.target" ];
+      partOf = [ "google-cloud-ops-agent.service" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "google-cloud-ops-agent";
+        Group = "google-cloud-ops-agent";
+        RuntimeDirectory = "google-cloud-ops-agent-fluent-bit";
+        StateDirectory = "google-cloud-ops-agent/fluent-bit";
+        LogsDirectory = "google-cloud-ops-agent/subagents";
+        Type = "simple";
+        ExecStartPre = "+${google-cloud-ops-agent}/bin/google_cloud_ops_agent_engine -service=fluentbit -in ${configFile} -logs \${LOGS_DIRECTORY} -state \${STATE_DIRECTORY}";
+        ExecStart = "${pkgs.fluent-bit}/bin/fluent-bit --config \${RUNTIME_DIRECTORY}/fluent_bit_main.conf --parser \${RUNTIME_DIRECTORY}/fluent_bit_parser.conf --log_file \${LOGS_DIRECTORY}/logging-module.log --storage_path \${STATE_DIRECTORY}/buffers";
+        Restart = "always";
+        RestartSec = "10s";
+        # For debugging:
+        RuntimeDirectoryPreserve = "yes";
+        # Security hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+      };
+    };
+
+    systemd.services.google-cloud-ops-agent-opentelemetry-collector = {
+      description = "Google Cloud Ops Agent - Metrics Agent";
+      wantedBy = [ "multi-user.target" ];
+      partOf = [ "google-cloud-ops-agent.service" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "google-cloud-ops-agent";
+        Group = "google-cloud-ops-agent";
+        RuntimeDirectory = "google-cloud-ops-agent-opentelemetry-collector";
+        StateDirectory = "google-cloud-ops-agent/opentelemetry-collector";
+        LogsDirectory = "google-cloud-ops-agent";
+        Type = "simple";
+        ExecStartPre = "+${google-cloud-ops-agent}/bin/google_cloud_ops_agent_engine -service=otel -in ${configFile} -logs \${LOGS_DIRECTORY} -state \${STATE_DIRECTORY}";
+        ExecStart = "${google-cloud-ops-agent-opentelemetry-collector}/bin/otelopscol --config \${RUNTIME_DIRECTORY}/otel.yaml";
+        Restart = "always";
+        RestartSec = "10s";
+        # For debugging:
+        RuntimeDirectoryPreserve = "yes";
+        # Security hardening
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        # Capabilities needed for reading process and system metrics
+        AmbientCapabilities = "CAP_SYS_PTRACE";
+      };
+    };
+
+    systemd.services.google-cloud-ops-agent = {
+      description = "Google Cloud Ops Agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [
+        "network-online.target"
+        "google-cloud-ops-agent-opentelemetry-collector.service"
+        "google-cloud-ops-agent-fluent-bit.service"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStartPre = "${google-cloud-ops-agent}/bin/google_cloud_ops_agent_engine -in ${configFile}";
+        ExecStart = "${pkgs.coreutils}/bin/true";
+        RemainAfterExit = "yes";
+      };
+    };
+  };
+}

--- a/nixos/modules/google-cloud-ops-agent/google-cloud-ops-agent-opentelemetry-collector.nix
+++ b/nixos/modules/google-cloud-ops-agent/google-cloud-ops-agent-opentelemetry-collector.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+}:
+stdenv.mkDerivation rec {
+  pname = "google-cloud-ops-agent-opentelemetry-collector";
+  version = "2.67.0";
+
+  src = fetchurl {
+    # Using pre-compiled debian package as according the the agent:
+    # "Building Google's custom otelopscol binary from source is incredibly complex since it involves Git submodules that invoke the OpenTelemetry ocb builder tool internally to dynamically generate Go code before compiling"
+    url = "https://packages.cloud.google.com/apt/pool/google-cloud-ops-agent-jammy-all/google-cloud-ops-agent_2.67.0~ubuntu22.04_amd64_74602eb5938d0cd2d9f9edb1044c888b.deb";
+    hash = "sha256-/JZ5Lf3oS95ZGORN3j5zMz5EX4kugpBoHuCVFq3rqPY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  unpackPhase = ''
+    dpkg -x $src .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol $out/bin/
+  '';
+}

--- a/nixos/modules/google-cloud-ops-agent/google-cloud-ops-agent.nix
+++ b/nixos/modules/google-cloud-ops-agent/google-cloud-ops-agent.nix
@@ -1,0 +1,32 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule rec {
+  pname = "ops-agent";
+  version = "2.67.0";
+  src = fetchFromGitHub {
+    owner = "GoogleCloudPlatform";
+    repo = "ops-agent";
+    rev = "refs/tags/${version}";
+    hash = "sha256-2jBFZkmbIDvpbp2hVzwYSDzhi8feMY5n+matRLmTFgQ=";
+  };
+  ldFlags = [
+    "-X github.com/GoogleCloudPlatform/ops-agent/internal/version.Version=${version}"
+    "-X github.com/GoogleCloudPlatform/ops-agent/internal/version.BuildDistro=nixos"
+  ];
+  subPackages = [
+    "cmd/google_cloud_ops_agent_engine"
+  ];
+
+  doCheck = false; # requires network access
+
+  vendorHash = "sha256-dO200wFvedyrMXj7vpfXXiLEf18BB/c8a/ZMxge9p/k=";
+  meta = with lib; {
+    description = "Agent that gather logs and metrics from your Google Compute Engine instances and send them to Cloud Logging and Cloud Monitoring";
+    homepage = "https://github.com/GoogleCloudPlatform/ops-agent";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This adds the Google Cloud Ops Agent and its OpenTelemetry Collector dependency, along with the NixOS module to configure and run them. The agent is used to gather logs and metrics from Google Compute Engine instances and send them to Cloud Logging and Cloud Monitoring.
