### PR TITLE
nixos/openssh: fix ssh-copy-id and nixos-anywhere

### DIFF
--- a/darwin/common/openssh.nix
+++ b/darwin/common/openssh.nix
@@ -1,12 +1,6 @@
 # Better defaults for OpenSSH
-{ lib, ... }:
 {
   environment.etc."ssh/sshd_config.d/102-srvos.conf".text = ''
-    # Only allow system-level authorized_keys to avoid injections.
-    # nix-darwin uses AuthorizedKeysCommand to set system-level keys
-    # https://github.com/LnL7/nix-darwin/blob/f61d5f2051a387a15817007220e9fb3bbead57b3/modules/programs/ssh/default.nix#L158
-    AuthorizedKeysFile none
-
     X11Forwarding no
     KbdInteractiveAuthentication no
     PasswordAuthentication no

--- a/nixos/common/openssh.nix
+++ b/nixos/common/openssh.nix
@@ -1,5 +1,4 @@
 # Better defaults for OpenSSH
-{ config, lib, ... }:
 {
   services.openssh = {
     settings.X11Forwarding = false;
@@ -8,19 +7,5 @@
     settings.UseDns = false;
     # unbind gnupg sockets if they exists
     settings.StreamLocalBindUnlink = true;
-
-    # Only allow system-level authorized_keys to avoid injections.
-    # We currently don't enable this when git-based software that relies on this is enabled.
-    # It would be nicer to make it more granular using `Match`.
-    # However those match blocks cannot be put after other `extraConfig` lines
-    # with the current sshd config module, which is however something the sshd
-    # config parser mandates.
-    authorizedKeysFiles = lib.mkIf (
-      !config.services.gitea.enable
-      && !config.services.gitlab.enable
-      && !config.services.gitolite.enable
-      && !config.services.gerrit.enable
-      && !config.services.forgejo.enable
-    ) (lib.mkForce [ "/etc/ssh/authorized_keys.d/%u" ]);
   };
 }


### PR DESCRIPTION
This breaks reinstalling an existing machine with `nixos-anywhere` as it relies on `ssh-copy-id` injecting a temporary deployment SSH key to `~/.ssh/authorized_keys`

This rule is not enabled by default in NixOS so I think it's fine to remove