### PR TITLE
Revert "add github pages effect"

### DIFF
--- a/dev/default.nix
+++ b/dev/default.nix
@@ -30,11 +30,8 @@
     };
   };
 
-  hercules-ci.github-pages.branch = "main";
-
   perSystem =
     {
-      config,
       lib,
       pkgs,
       self',
@@ -46,10 +43,6 @@
       inherit (pkgs.stdenv.hostPlatform) isLinux;
     in
     {
-      hercules-ci.github-pages.settings = {
-        contents = config.packages.docs;
-      };
-
       checks =
         let
           devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;


### PR DESCRIPTION
Reverts nix-community/srvos#843

Reverting this as it isn't working (maybe because of the dev flake wiring) and failed effect doesn't have a failed status on github. https://github.com/Mic92/nixbot/issues/30