### PR TITLE
remove cache.garnix.io substituter

### DIFF
--- a/shared/mixins/trusted-nix-caches.nix
+++ b/shared/mixins/trusted-nix-caches.nix
@@ -3,12 +3,10 @@
   # flakes but are not enabled by default.
   nix.settings.trusted-substituters = [
     "https://nix-community.cachix.org"
-    "https://cache.garnix.io"
     "https://numtide.cachix.org"
   ];
   nix.settings.trusted-public-keys = [
     "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-    "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
   ];
 }


### PR DESCRIPTION
[garnix](https://garnix.io/) has been discontinued, and as such https://cache.garnix.io/ is now offline. there's no reason to keep the substituter and the key

my configuration includes `nix.settings.substituters = config.nix.settings.trusted-substituters`, which causes Nix to attempt, fail, and retry fetching the cache information