### PR TITLE
chore(nix): `nix.settings.log-lines` already defaults to 25

### DIFF
--- a/shared/common/nix.nix
+++ b/shared/common/nix.nix
@@ -14,9 +14,6 @@
   ]
   ++ lib.optional (lib.versionOlder (lib.versions.majorMinor config.nix.package.version) "2.22") "repl-flake";
 
-  # The default at 10 is rarely enough.
-  nix.settings.log-lines = lib.mkDefault 25;
-
   # Avoid disk full issues
   nix.settings.max-free = lib.mkDefault (3000 * 1024 * 1024);
   nix.settings.min-free = lib.mkDefault (512 * 1024 * 1024);


### PR DESCRIPTION
Remove `nix.settings.log-lines` as it already defaults to 25.